### PR TITLE
Fix for handling H5AD's factors in the sample_factor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bakana",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Backend for kana's single-cell analyses. This supports single or multiple samples, execution in Node.js or the browser, in-memory caching of results for iterative analyses, and serialization to/from file for redistribution.",
   "type": "module",
   "main": "main/index.js",

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -336,6 +336,13 @@ async function process_datasets(matrices, sample_factor) {
             // Single matrix with a batch factor.
             try {
                 let anno_batch = current.annotations[sample_factor];
+
+                let anno_levels = null;
+                if (utils.isObject(anno_batch)) {
+                    anno_levels = anno_batch.levels;
+                    anno_batch = anno_batch.index;
+                }
+
                 let ncols = current.matrix.numberOfColumns();
                 if (anno_batch.length != ncols) {
                     throw new Error("length of sample factor '" + sample_factor + "' should be equal to the number of cells"); 
@@ -353,6 +360,11 @@ async function process_datasets(matrices, sample_factor) {
                     }
                     block_arr[i] = uvals[x];
                 });
+
+                if (anno_levels !== null) {
+                    block_levels = Array.from(block_levels).map(i => anno_levels[i]);
+                }
+
             } catch (e) {
                 utils.freeCache(blocks);
                 utils.freeCache(current.matrix);


### PR DESCRIPTION
Arguably dealing with H5AD factors has been more trouble than it's worth and we should just coerce everything to an array of strings. Data's not large enough to have any performance impact and we can get rid of all the object-related protection.