### PR TITLE
Allow QC filtering to be turned off, e.g., for pre-filtered data.

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -22,6 +22,7 @@ export function analysisDefaults() {
             sample_factor: null
         },
         quality_control: {
+            method: "auto",
             use_mito_default: true,
             mito_prefix: "mt-",
             nmads: 3

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -22,10 +22,10 @@ export function analysisDefaults() {
             sample_factor: null
         },
         quality_control: {
-            method: "auto",
             use_mito_default: true,
             mito_prefix: "mt-",
-            nmads: 3
+            nmads: 3,
+            filter: true
         },
         feature_selection: {
             span: 0.3

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,7 @@ export async function runAnalysis(state, matrices, params, { startFun = null, fi
 
     quickStart(step_qc);
     state[step_qc].compute(
+        params[step_qc]["method"], 
         params[step_qc]["use_mito_default"], 
         params[step_qc]["mito_prefix"], 
         params[step_qc]["nmads"]

--- a/src/index.js
+++ b/src/index.js
@@ -197,10 +197,10 @@ export async function runAnalysis(state, matrices, params, { startFun = null, fi
 
     quickStart(step_qc);
     state[step_qc].compute(
-        params[step_qc]["method"], 
         params[step_qc]["use_mito_default"], 
         params[step_qc]["mito_prefix"], 
-        params[step_qc]["nmads"]
+        params[step_qc]["nmads"],
+        params[step_qc]["filter"] 
     );
     quickFinish(step_qc);
 

--- a/src/quality_control.js
+++ b/src/quality_control.js
@@ -197,13 +197,17 @@ export class QualityControlState {
             // Resetting the thresholds if we actually don't want any filtering.
             // TODO: move this into computePerCellQCFilters to support custom thresholds.
             if (!filter) {
-                this.#cache.filters.thresholdsSums({ copy: false }).fill(0);
+                this.#cache.filters.thresholdsSums({ copy: false }).fill(1);
                 this.#cache.filters.thresholdsDetected({ copy: false }).fill(0);
                 this.#cache.filters.thresholdsSubsetProportions(0, { copy: false }).fill(1);
                 this.#cache.filters.discardSums({ copy: false }).fill(0);
                 this.#cache.filters.discardDetected({ copy: false }).fill(0);
                 this.#cache.filters.discardSubsetProportions(0, { copy: false }).fill(0);
-                this.#cache.filters.discardOverall({ copy: false }).fill(0);
+
+                // Though we are forced to remove zero-count cells, otherwise normalization will fail.
+                let sums = this.fetchSums({ unsafe: true });
+                let disc = this.#cache.filters.discardOverall({ copy: false });
+                sums.forEach((x, i) => disc[i] = (x == 0));
             }
 
             this.#parameters.nmads = nmads;

--- a/src/quality_control.js
+++ b/src/quality_control.js
@@ -94,7 +94,7 @@ export class QualityControlState {
      */
     fetchFilteredAnnotations(col) { 
         let vec = this.#inputs.fetchAnnotations(col);
-        if (!this.#parameters.filter) {
+        if (this.#parameters.filter) {
             var discard = this.fetchDiscards().array();
             let filterfun = (x, i) => !discard[i];
             if (vec.type === "factor") {

--- a/tests/qc.test.js
+++ b/tests/qc.test.js
@@ -8,7 +8,7 @@ afterAll(async () => await bakana.terminate());
 test("runAnalysis works correctly when QC method is 'none'", async () => {
     let state = await bakana.createAnalysis();
     let params = utils.baseParams();
-    params.quality_control.method = "none";
+    params.quality_control.filter = false;
 
     let res = await bakana.runAnalysis(state, 
         { 
@@ -27,7 +27,13 @@ test("runAnalysis works correctly when QC method is 'none'", async () => {
     let lost = 0;
     disc.forEach(x => lost += x);
     expect(lost).toBe(0);
-    
+
+    // Check that the getters work.
+    let anno = state.quality_control.fetchFilteredAnnotations("AAACATACAACCAC-1");
+    expect(anno.index.length).toBe(disc.length);
+
+    expect(state.quality_control.fetchFilteredBlock()).toBeNull();
+
     // Saving and loading.
     const path = "TEST_state_no_qc.h5";
     let collected = await bakana.saveAnalysis(state, path);
@@ -41,7 +47,7 @@ test("runAnalysis works correctly when QC method is 'none'", async () => {
     );
 
     let new_params = reloaded.parameters;
-    expect(new_params.quality_control.method).toBe("none");
+    expect(new_params.quality_control.filter).toBe(false);
 
     // Release me!
     await bakana.freeAnalysis(state);

--- a/tests/qc.test.js
+++ b/tests/qc.test.js
@@ -1,0 +1,48 @@
+import * as bakana from "../src/index.js";
+import * as scran from "scran.js";
+import * as utils from "./utils.js";
+
+beforeAll(async () => await bakana.initialize({ localFile: true }));
+afterAll(async () => await bakana.terminate());
+
+test("runAnalysis works correctly when QC method is 'none'", async () => {
+    let state = await bakana.createAnalysis();
+    let params = utils.baseParams();
+    params.quality_control.method = "none";
+
+    let res = await bakana.runAnalysis(state, 
+        { 
+            default: {
+                format: "MatrixMarket",
+                mtx: "files/datasets/pbmc3k-matrix.mtx.gz",
+                genes: "files/datasets/pbmc3k-features.tsv.gz",
+                annotations: "files/datasets/pbmc3k-barcodes.tsv.gz"
+            }
+        },
+        params
+    );
+
+    // Checking that nothing was discarded.
+    let disc = state.quality_control.fetchDiscards();
+    let lost = 0;
+    disc.forEach(x => lost += x);
+    expect(lost).toBe(0);
+    
+    // Saving and loading.
+    const path = "TEST_state_no_qc.h5";
+    let collected = await bakana.saveAnalysis(state, path);
+    expect(collected.collected.length).toBe(3);
+    expect(typeof(collected.collected[0])).toBe("string");
+
+    let offsets = utils.mockOffsets(collected.collected);
+    let reloaded = await bakana.loadAnalysis(
+        path, 
+        (offset, size) => offsets[offset]
+    );
+
+    let new_params = reloaded.parameters;
+    expect(new_params.quality_control.method).toBe("none");
+
+    // Release me!
+    await bakana.freeAnalysis(state);
+})


### PR DESCRIPTION
This will require a new UI option in **kana**, as well as an update of the **kanaval** specification to consider `quality_control.filter`. 