### PR TITLE
Provide methods to directly report the (filtered) QC statistics.

### DIFF
--- a/src/steps/adt_quality_control.js
+++ b/src/steps/adt_quality_control.js
@@ -67,6 +67,30 @@ export class AdtQualityControlState extends qcutils.QualityControlStateBase {
         return output;
     }
 
+    /**
+     * Fetch one type of metric used for evaluating per-cell quality from the ADT count matrix.
+     *
+     * @param {string} metric - Type of statistic.
+     * This may be any of `"sums"`, `"detected"` or `"igg_total"`.
+     * @param {object} [options={}] - Optional parameters.
+     * @param {boolean} [options.unsafe=false] - Whether to return the view on the Wasm heap directly.
+     * By default, a copy is created.
+     *
+     * @return {Float64Array} Array of QC statistics for each cell in the dataset.
+     * If `unsafe = true`, this may be a view on the Wasm heap and may be invalidated on the next allocation.
+     */
+    fetchQualityMetric(metric, { unsafe = false } = {}) {
+        if (metric == "sums") {
+            return this.fetchSums({ unsafe });
+        } else if (metric == "detected") {
+            return this.#cache.metrics.detected({ copy: !unsafe });
+        } else if (metric == "igg_total") {
+            return this.#cache.metrics.subsetTotals(0, { copy: !unsafe });
+        } else {
+            throw new Error("unknown QC statistic '" + metric + "'");
+        }
+    }
+
     /***************************
      ******** Compute **********
      ***************************/

--- a/src/steps/cell_filtering.js
+++ b/src/steps/cell_filtering.js
@@ -96,11 +96,30 @@ export class CellFilteringState {
     }
 
     /**
+     * Fetch the filtered quality control metrics.
+     *
+     * @param {string} metric - Type of quality metric.
+     * This may be `"sums"`, `"detected"` and `"proportion"` (for RNA) or `"igg_total"` (for ADT).
+     * @param {string} modality - Modality of interest, e.g., `"RNA"` or `"ADT"`.
+     *
+     * @return {TypedArray} Array of length equal to the number of cells after filtering, containing the metrics of interest.
+     */
+    fetchFilteredQualityMetric(metric, modality) {
+        let vec = this.#qc_states[modality].fetchQualityMetric(metric, { unsafe: true });
+        if ("discard_buffer" in this.#cache) {
+            var discard = this.#cache.discard_buffer.array();
+            return vec.filter((x, i) => !discard[i]);
+        } else {
+            return vec.slice(); // making a copy.
+        }
+    }
+
+    /**
      * Fetch an annotation for the cells remaining after QC filtering.
      *
      * @param {string} col - Name of the annotation field of interest.
      *
-     * @return {Array|TypedArray} Array of length equal to the number of filtered cells, containing the requested annotations.
+     * @return {Array|TypedArray} Array of length equal to the number of cells after filtering, containing the requested annotations.
      */
     fetchFilteredAnnotations(col) { 
         let vec = this.#inputs.fetchAnnotations(col);

--- a/src/steps/quality_control.js
+++ b/src/steps/quality_control.js
@@ -64,6 +64,30 @@ export class QualityControlState extends qcutils.QualityControlStateBase {
         return { ...this.#parameters }; // avoid pass-by-reference links.
     }
 
+    /**
+     * Fetch one type of metric used for evaluating per-cell quality from the RNA count matrix.
+     *
+     * @param {string} metric - Type of statistic.
+     * This may be any of `"sums"`, `"detected"` or `"proportion"`.
+     * @param {object} [options={}] - Optional parameters.
+     * @param {boolean} [options.unsafe=false] - Whether to return the view on the Wasm heap directly.
+     * By default, a copy is created.
+     *
+     * @return {Float64Array} Array of QC statistics for each cell in the dataset.
+     * If `unsafe = true`, this may be a view on the Wasm heap and may be invalidated on the next allocation.
+     */
+    fetchQualityMetric(metric, { unsafe = false } = {}) {
+        if (metric == "sums") {
+            return this.fetchSums({ unsafe });
+        } else if (metric == "detected") {
+            return this.#cache.metrics.detected({ copy: !unsafe });
+        } else if (metric == "proportion") {
+            return this.#cache.metrics.subsetProportions(0, { copy: !unsafe });
+        } else {
+            throw new Error("unknown QC statistic '" + metric + "'");
+        }
+    }
+
     /***************************
      ******** Compute **********
      ***************************/

--- a/tests/MatrixMarket.test.js
+++ b/tests/MatrixMarket.test.js
@@ -59,6 +59,12 @@ test("runAnalysis works correctly (MatrixMarket)", async () => {
         expect(idx[1]).toBeGreaterThan(last_filtered);
         expect(state.inputs.fetchCountMatrix().column(idx[0])).toEqual(state.cell_filtering.fetchFilteredMatrix().column(0));
         expect(state.inputs.fetchCountMatrix().column(idx[1])).toEqual(state.cell_filtering.fetchFilteredMatrix().column(last_filtered));
+
+        for (const metric of Object.keys(contents.quality_control.data.default)) { 
+            let metvec = state.cell_filtering.fetchFilteredQualityMetric(metric, "RNA");
+            expect(metvec instanceof Float64Array || metvec instanceof Int32Array).toBe(true);
+            expect(metvec.length).toEqual(contents.cell_filtering.retained);
+        }
     }
 
     // Markers.

--- a/tests/adt.test.js
+++ b/tests/adt.test.js
@@ -90,6 +90,13 @@ test("runAnalysis works correctly (MatrixMarket)", async () => {
         expect(positive_total).toBeGreaterThan(0);
         expect(summ.thresholds.default.detected).toBeGreaterThan(0);
         expect(summ.thresholds.default.igg_total).toBeGreaterThan(0);
+
+        let retained = state.cell_filtering.summary().retained;
+        for (const metric of Object.keys(summ.data.default)) { 
+            let metvec = state.cell_filtering.fetchFilteredQualityMetric(metric, "ADT");
+            expect(metvec instanceof Float64Array || metvec instanceof Int32Array).toBe(true);
+            expect(metvec.length).toEqual(retained);
+        }
     }
 
     {

--- a/tests/quality_control.test.js
+++ b/tests/quality_control.test.js
@@ -36,6 +36,9 @@ test("analysis works when we skip the QC steps", async () => {
     let ncells = state.inputs.fetchCountMatrix().numberOfColumns();
     expect(state.cell_filtering.fetchFilteredMatrix().numberOfColumns()).toBe(ncells);
 
+    let sums = state.inputs.fetchFilteredQualityMetric("sums", "RNA");
+    expect(sums.length).toBe(ncells);
+
     const path = "TEST_state_qc-skip.h5";
     let collected = await bakana.saveAnalysis(state, path);
     utils.validateState(path);


### PR DESCRIPTION
This works for both RNA and ADT, and before and after filtering.